### PR TITLE
update to rust 2021

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -82,7 +82,7 @@ rec {
     serde = "1.0.70";
     parse_zoneinfo = "0.1.1";
   };
-  deps.dimensioned."0.7.0" = {
+  deps.dimensioned."0.8.0" = {
     generic_array = "0.11.1";
     num_traits = "0.2.5";
     serde = "1.0.70";
@@ -92,7 +92,7 @@ rec {
   deps.emseries."0.4.0" = {
     chrono = "0.4.4";
     chrono_tz = "0.4.1";
-    dimensioned = "0.7.0";
+    dimensioned = "0.8.0";
     serde = "1.0.70";
     serde_derive = "1.0.76";
     serde_json = "1.0.24";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/emseries"
 homepage = "https://github.com/luminescent-dreams/emseries"
 repository = "https://github.com/luminescent-dreams/emseries"
 categories = ["database-implementations"]
+edition = "2021"
 
 include = [
     "**/*.rs",
@@ -18,7 +19,7 @@ include = [
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.4", features = ["serde"] }
-dimensioned = { version = "0.7.0", features = ["serde"] }
+dimensioned = { version = "0.8.0", features = ["serde"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"

--- a/crates-io.list
+++ b/crates-io.list
@@ -3,7 +3,7 @@ bitflags-1.0.3
 cfg-if-0.1.4
 chrono-0.4.4
 chrono-tz-0.4.1
-dimensioned-0.7.0
+dimensioned-0.8.0
 dtoa-0.4.3
 fuchsia-zircon-0.3.3
 fuchsia-zircon-sys-0.3.3

--- a/src/criteria.rs
+++ b/src/criteria.rs
@@ -1,5 +1,5 @@
-use date_time_tz::DateTimeTz;
-use types::Recordable;
+use crate::date_time_tz::DateTimeTz;
+use crate::types::Recordable;
 
 /// This trait is used for constructing queries for searching the database.
 pub trait Criteria {
@@ -8,13 +8,11 @@ pub trait Criteria {
     fn apply<T: Recordable>(&self, record: &T) -> bool;
 }
 
-
 /// Specify two criteria that must both be matched.
 pub struct And<A: Criteria, B: Criteria> {
     pub lside: A,
     pub rside: B,
 }
-
 
 impl<A, B> Criteria for And<A, B>
 where
@@ -26,13 +24,11 @@ where
     }
 }
 
-
 /// Specify two criteria, either of which may be matched.
 pub struct Or<A: Criteria, B: Criteria> {
     pub lside: A,
     pub rside: B,
 }
-
 
 /// Specify the starting time for a search. This consists of a UTC timestamp and a specifier as to
 /// whether the exact time is included in the search criteria.
@@ -40,7 +36,6 @@ pub struct StartTime {
     pub time: DateTimeTz,
     pub incl: bool,
 }
-
 
 impl Criteria for StartTime {
     fn apply<T: Recordable>(&self, record: &T) -> bool {
@@ -52,14 +47,12 @@ impl Criteria for StartTime {
     }
 }
 
-
 /// Specify the ending time for a search. This consists of a UTC timestamp and a specifier as to
 /// whether the exact time is included in the search criteria.
 pub struct EndTime {
     pub time: DateTimeTz,
     pub incl: bool,
 }
-
 
 impl Criteria for EndTime {
     fn apply<T: Recordable>(&self, record: &T) -> bool {
@@ -71,7 +64,6 @@ impl Criteria for EndTime {
     }
 }
 
-
 /// Specify a list of tags that must exist on the record.
 pub struct Tags {
     pub tags: Vec<String>,
@@ -80,12 +72,9 @@ pub struct Tags {
 impl Criteria for Tags {
     fn apply<T: Recordable>(&self, record: &T) -> bool {
         let record_tags = record.tags();
-        self.tags
-            .iter()
-            .all(|v| record_tags.contains(v))
+        self.tags.iter().all(|v| record_tags.contains(v))
     }
 }
-
 
 /// Specify a criteria that searches for records matching an exact time.
 pub fn exact_time(time: DateTimeTz) -> And<StartTime, EndTime> {
@@ -97,7 +86,6 @@ pub fn exact_time(time: DateTimeTz) -> And<StartTime, EndTime> {
         rside: EndTime { time, incl: true },
     }
 }
-
 
 /// Specify a criteria that searches for all records within a time range.
 pub fn time_range(

--- a/src/date_time_tz.rs
+++ b/src/date_time_tz.rs
@@ -35,10 +35,9 @@ impl DateTimeTz {
         } else {
             format!(
                 "{} {}",
-                self.0.with_timezone(&chrono_tz::Etc::UTC).to_rfc3339_opts(
-                    SecondsFormat::Secs,
-                    true,
-                ),
+                self.0
+                    .with_timezone(&chrono_tz::Etc::UTC)
+                    .to_rfc3339_opts(SecondsFormat::Secs, true,),
                 self.0.timezone().name()
             )
         }
@@ -65,9 +64,9 @@ impl<'de> Visitor<'de> for DateTimeTzVisitor {
     }
 
     fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
-        DateTimeTz::from_str(s).or(Err(E::custom(
-            format!("string is not a parsable datetime representation"),
-        )))
+        DateTimeTz::from_str(s).or(Err(E::custom(format!(
+            "string is not a parsable datetime representation"
+        ))))
     }
 }
 
@@ -87,36 +86,51 @@ impl<'de> Deserialize<'de> for DateTimeTz {
 mod test {
     extern crate serde_json;
 
+    use crate::date_time_tz::DateTimeTz;
     use chrono::TimeZone;
-    use chrono_tz::Etc::UTC;
     use chrono_tz::America::Phoenix;
+    use chrono_tz::Etc::UTC;
     use chrono_tz::US::{Arizona, Central};
-    use date_time_tz::DateTimeTz;
 
     #[test]
     fn it_creates_timestamp_with_z() {
-        let t = DateTimeTz(UTC.ymd(2019, 5, 15).and_hms(12, 0, 0));
+        let t = DateTimeTz(UTC.with_ymd_and_hms(2019, 5, 15, 12, 0, 0).unwrap());
         assert_eq!(t.to_string(), "2019-05-15T12:00:00Z");
     }
 
     #[test]
     fn it_parses_utc_rfc3339_z() {
         let t = DateTimeTz::from_str("2019-05-15T12:00:00Z").unwrap();
-        assert_eq!(t, DateTimeTz(UTC.ymd(2019, 5, 15).and_hms(12, 0, 0)));
+        assert_eq!(
+            t,
+            DateTimeTz(UTC.with_ymd_and_hms(2019, 5, 15, 12, 0, 0).unwrap())
+        );
     }
 
     #[test]
     fn it_parses_rfc3339_with_offset() {
         let t = DateTimeTz::from_str("2019-05-15T12:00:00-06:00").unwrap();
-        assert_eq!(t, DateTimeTz(UTC.ymd(2019, 5, 15).and_hms(18, 0, 0)));
+        assert_eq!(
+            t,
+            DateTimeTz(UTC.with_ymd_and_hms(2019, 5, 15, 18, 0, 0).unwrap())
+        );
     }
 
     #[test]
     fn it_parses_rfc3339_with_tz() {
         let t = DateTimeTz::from_str("2019-06-15T19:00:00Z US/Arizona").unwrap();
-        assert_eq!(t, DateTimeTz(UTC.ymd(2019, 6, 15).and_hms(19, 0, 0)));
-        assert_eq!(t, DateTimeTz(Arizona.ymd(2019, 6, 15).and_hms(12, 0, 0)));
-        assert_eq!(t, DateTimeTz(Central.ymd(2019, 6, 15).and_hms(14, 0, 0)));
+        assert_eq!(
+            t,
+            DateTimeTz(UTC.with_ymd_and_hms(2019, 6, 15, 19, 0, 0).unwrap())
+        );
+        assert_eq!(
+            t,
+            DateTimeTz(Arizona.with_ymd_and_hms(2019, 6, 15, 12, 0, 0).unwrap())
+        );
+        assert_eq!(
+            t,
+            DateTimeTz(Central.with_ymd_and_hms(2019, 6, 15, 14, 0, 0).unwrap())
+        );
         assert_eq!(t.to_string(), "2019-06-15T19:00:00Z US/Arizona");
     }
 
@@ -148,8 +162,11 @@ mod test {
 
     #[test]
     fn it_json_parses() {
-        let t = serde_json::from_str::<DateTimeTz>("\"2019-06-15T19:00:00Z America/Phoenix\"")
-            .unwrap();
-        assert_eq!(t, DateTimeTz(Phoenix.ymd(2019, 6, 15).and_hms(12, 0, 0)));
+        let t =
+            serde_json::from_str::<DateTimeTz>("\"2019-06-15T19:00:00Z America/Phoenix\"").unwrap();
+        assert_eq!(
+            t,
+            DateTimeTz(Phoenix.with_ymd_and_hms(2019, 6, 15, 12, 0, 0).unwrap())
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod date_time_tz;
 mod series;
 mod types;
 
-pub use date_time_tz::DateTimeTz;
 pub use criteria::*;
+pub use date_time_tz::DateTimeTz;
 pub use series::Series;
 pub use types::{Error, Record, Recordable, UniqueId};


### PR DESCRIPTION
# Rust 2021 Edition Updates

This doesn't introduce any functional changes, just updates the rust version, takes care of some deprecated method calls and bumps a soon-to-be unsupported dependency, and ran it through `fmt` and `clippy`.  
